### PR TITLE
feat: add authentication

### DIFF
--- a/sna-steward/App.swift
+++ b/sna-steward/App.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+@main
+struct SNAStewardApp: App {
+  // Initialize environment and Supabase at app startup
+  init() {
+      // Ensure DotEnv is loaded first to populate environment variables
+      _ = DotEnv.shared
+      
+      // Initialize Supabase manager after environment variables are loaded
+      _ = SupabaseManager.shared
+  }
+  
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+struct ContentView: View {
+    @StateObject private var authViewModel = AuthViewModel()
+    
+    var body: some View {
+        if authViewModel.isAuthenticated {
+            if authViewModel.isFirstTimeUser {
+                SelectSnaSiteView(viewModel: authViewModel)
+            } else {
+                MainTabView(viewModel: authViewModel)
+            }
+        } else {
+            SignInView(viewModel: authViewModel)
+        }
+    }
+} 

--- a/sna-steward/Features/BirdChecklist/BirdChecklistView.swift
+++ b/sna-steward/Features/BirdChecklist/BirdChecklistView.swift
@@ -57,5 +57,8 @@ struct BirdCheckListView: View {
 }
 
 #Preview {
-  BirdCheckListView()
+  // Setup mock environment for preview
+  DotEnv.setupForPreviews()
+  
+  return BirdCheckListView()
 }

--- a/sna-steward/Features/Observation/ObservationView.swift
+++ b/sna-steward/Features/Observation/ObservationView.swift
@@ -149,5 +149,8 @@ struct ObservationView: View {
 }
 
 #Preview {
-    ObservationView()
+    // Setup mock environment for preview
+    DotEnv.setupForPreviews()
+    
+    return ObservationView()
 } 

--- a/sna-steward/Features/PlantChecklist/PlantChecklistView.swift
+++ b/sna-steward/Features/PlantChecklist/PlantChecklistView.swift
@@ -29,5 +29,8 @@ struct PlantCheckListView: View {
 }
 
 #Preview {
-  PlantCheckListView()
+  // Setup mock environment for preview
+  DotEnv.setupForPreviews()
+  
+  return PlantCheckListView()
 }

--- a/sna-steward/Models/Steward.swift
+++ b/sna-steward/Models/Steward.swift
@@ -1,0 +1,10 @@
+// Models/Steward.swift
+import Foundation
+
+struct Steward: Identifiable, Codable, Hashable {
+    let id: UUID
+    var sna_site: String? // Make it optional if it can be NULL
+    let created_at: Date // Supabase sends ISO8601, decoding should handle it
+
+    // Add other fields if needed
+} 

--- a/sna-steward/Preview Content/PreviewHelper.swift
+++ b/sna-steward/Preview Content/PreviewHelper.swift
@@ -1,0 +1,45 @@
+import Foundation
+import SwiftUI
+
+/// Helper for setting up SwiftUI previews with mocked dependencies
+struct PreviewHelper {
+    /// Set up all the environment needs for previews
+    static func setupPreviewEnvironment() {
+        // Set preview flag
+        setenv("XCODE_RUNNING_FOR_PREVIEWS", "1", 1)
+        
+        // First set up the mock environment variables
+        DotEnv.setupForPreviews()
+        
+        print("🔧 Preview environment setup complete")
+    }
+    
+    /// Create a preview-ready AuthViewModel with mocked dependencies
+    static func createMockAuthViewModel() -> AuthViewModel {
+        // First ensure the environment is set up
+        setupPreviewEnvironment()
+        
+        // Create the view model
+        let viewModel = AuthViewModel()
+        
+        // Setup some default values for convenient preview
+        viewModel.selectedSnaSite = "Green Valley SNA"
+        
+        // Return the configured view model
+        return viewModel
+    }
+    
+    /// Create a simplified preview-ready AuthViewModel that appears authenticated
+    static func createAuthenticatedViewModel() -> AuthViewModel {
+        let viewModel = createMockAuthViewModel()
+        viewModel.isAuthenticated = true
+        return viewModel
+    }
+    
+    /// Create a simplified preview-ready AuthViewModel for a first-time user
+    static func createFirstTimeUserViewModel() -> AuthViewModel {
+        let viewModel = createAuthenticatedViewModel()
+        viewModel.isFirstTimeUser = true
+        return viewModel
+    }
+} 

--- a/sna-steward/Preview Content/PreviewModels.swift
+++ b/sna-steward/Preview Content/PreviewModels.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Mock StewardProfile model used in previews
+struct StewardProfile {
+    let id: UUID
+    let user_id: UUID
+    let sna_site: String
+    let created_at: Date
+    let updated_at: Date
+} 

--- a/sna-steward/Preview Content/PreviewSupabaseManager.swift
+++ b/sna-steward/Preview Content/PreviewSupabaseManager.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Supabase
+import ObjectiveC
+
+/// A special version of SupabaseManager for SwiftUI previews
+class PreviewSupabaseManager {
+    /// Shared preview instance
+    static let shared = PreviewSupabaseManager()
+    
+    /// Mock Supabase URL
+    private let supabaseURL = URL(string: "https://example-preview.supabase.co")!
+    
+    /// Mock Supabase key
+    private let supabaseKey = "example-preview-anon-key"
+    
+    /// Mock Supabase client
+    lazy var client = SupabaseClient(
+        supabaseURL: supabaseURL,
+        supabaseKey: supabaseKey
+    )
+    
+    private init() {}
+    
+    /// Setup the environment for previews
+    static func setupPreviewEnvironment() {
+        // Set up mock environment variables first
+        DotEnv.setupForPreviews()
+        
+        // Note: We don't actually replace the shared instance in preview mode
+        // as it would require unsafe runtime manipulation
+        print("📱 Using PreviewSupabaseManager for previews")
+    }
+    
+    // MARK: - Mock Auth Methods
+    
+    func signIn(email: String, password: String) async throws -> Session {
+        // Return a mock session with the correct parameters
+        return Session(
+            providerToken: nil,
+            providerRefreshToken: nil,
+            accessToken: "mock-access-token",
+            tokenType: "bearer",
+            expiresIn: 3600,
+            expiresAt: Date().timeIntervalSince1970 + 3600,
+            refreshToken: "mock-refresh-token",
+            weakPassword: nil,
+            user: createMockUser(email: email)
+        )
+    }
+    
+    func signUp(email: String, password: String) async throws -> AuthResponse {
+        // For preview purposes, just sign in since we don't need an actual AuthResponse
+        // This avoids serialization issues with the real AuthResponse
+        _ = createMockUser(email: email)
+        
+        // Throw a custom error that we can catch in the preview
+        struct PreviewSignUpSuccess: Error, LocalizedError {
+            var errorDescription: String? { "Preview sign-up successful. This is expected." }
+        }
+        throw PreviewSignUpSuccess()
+    }
+    
+    func signOut() async throws {
+        // Mock sign out - does nothing in preview
+    }
+    
+    func signInWithMagicLink(email: String) async throws {
+        // Mock sending magic link - does nothing in preview
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func createMockUser(email: String) -> User {
+        return User(
+            id: UUID(),
+            appMetadata: [:],
+            userMetadata: [:],
+            aud: "authenticated",
+            confirmationSentAt: nil,
+            recoverySentAt: nil,
+            emailChangeSentAt: nil,
+            newEmail: nil,
+            invitedAt: nil,
+            actionLink: nil,
+            email: email,
+            phone: nil,
+            createdAt: Date(),
+            confirmedAt: Date(),
+            emailConfirmedAt: Date(),
+            phoneConfirmedAt: nil,
+            lastSignInAt: Date(),
+            role: nil,  // Use 'role' instead of 'roleId'
+            updatedAt: Date(),
+            identities: nil,
+            factors: nil
+        )
+    }
+    
+    // MARK: - Mock Database Methods
+    
+    func updateSnaSiteForCurrentUser(newSite: String) async throws {
+        // Mock updating SNA site - does nothing in preview
+    }
+    
+    func fetchCurrentUserStewardProfile() async throws -> StewardProfile? {
+        // Return a mock profile
+        return StewardProfile(
+            id: UUID(),
+            user_id: UUID(),
+            sna_site: "Green Valley SNA",
+            created_at: Date(),
+            updated_at: Date()
+        )
+    }
+} 

--- a/sna-steward/SNA_StewardApp.swift
+++ b/sna-steward/SNA_StewardApp.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-@main
+//@main
 struct SNA_StewardApp: App {
     // Initialize environment and Supabase at app startup
     init() {
@@ -20,7 +20,7 @@ struct SNA_StewardApp: App {
     
     var body: some Scene {
         WindowGroup {
-            MainTabView()
+//            MainTabView()
         }
     }
 }

--- a/sna-steward/Utilities/BiometricAuthHelper.swift
+++ b/sna-steward/Utilities/BiometricAuthHelper.swift
@@ -1,0 +1,116 @@
+import Foundation
+import LocalAuthentication
+import Security
+
+class BiometricAuthHelper {
+    enum BiometricType {
+        case none
+        case touchID
+        case faceID
+        
+        var description: String {
+            switch self {
+            case .none: return "None"
+            case .touchID: return "Touch ID"
+            case .faceID: return "Face ID"
+            }
+        }
+    }
+    
+    enum BiometricError: LocalizedError {
+        case authenticationFailed
+        case userCancel
+        case userFallback
+        case biometryNotAvailable
+        case biometryNotEnrolled
+        case biometryLockout
+        case unknown
+        
+        var errorDescription: String? {
+            switch self {
+            case .authenticationFailed: return "Authentication failed"
+            case .userCancel: return "User canceled"
+            case .userFallback: return "User fallback"
+            case .biometryNotAvailable: return "Biometry not available"
+            case .biometryNotEnrolled: return "Biometry not enrolled"
+            case .biometryLockout: return "Biometry lockout"
+            case .unknown: return "Unknown error"
+            }
+        }
+    }
+    
+    static let shared = BiometricAuthHelper()
+    private init() {}
+    
+    // Check if device supports biometrics
+    func biometricType() -> BiometricType {
+        let context = LAContext()
+        var error: NSError?
+        
+        guard context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
+            return .none
+        }
+        
+        if #available(iOS 11.0, *) {
+            switch context.biometryType {
+            case .touchID:
+                return .touchID
+            case .faceID:
+                return .faceID
+            case .none:
+                return .none
+            @unknown default:
+                return .none
+            }
+        } else {
+            return context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) ? .touchID : .none
+        }
+    }
+    
+    // Authenticate with biometrics
+    func authenticate(reason: String) async throws {
+        let context = LAContext()
+        var authError: NSError?
+        
+        // Check if we can use biometric authentication
+        guard context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &authError) else {
+            if let error = authError {
+                switch error.code {
+                case LAError.biometryNotAvailable.rawValue:
+                    throw BiometricError.biometryNotAvailable
+                case LAError.biometryNotEnrolled.rawValue:
+                    throw BiometricError.biometryNotEnrolled
+                case LAError.biometryLockout.rawValue:
+                    throw BiometricError.biometryLockout
+                default:
+                    throw BiometricError.unknown
+                }
+            }
+            throw BiometricError.unknown
+        }
+        
+        do {
+            let success = try await context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: reason)
+            if !success {
+                throw BiometricError.authenticationFailed
+            }
+        } catch let error as LAError {
+            switch error.code {
+            case .authenticationFailed:
+                throw BiometricError.authenticationFailed
+            case .userCancel:
+                throw BiometricError.userCancel
+            case .userFallback:
+                throw BiometricError.userFallback
+            case .biometryNotAvailable:
+                throw BiometricError.biometryNotAvailable
+            case .biometryNotEnrolled:
+                throw BiometricError.biometryNotEnrolled
+            case .biometryLockout:
+                throw BiometricError.biometryLockout
+            default:
+                throw BiometricError.unknown
+            }
+        }
+    }
+} 

--- a/sna-steward/Utilities/DotEnv.swift
+++ b/sna-steward/Utilities/DotEnv.swift
@@ -6,8 +6,10 @@ struct DotEnv {
     
     private var variables: [String: String] = [:]
     
-    init() {
-        loadEnvFile()
+    init(skipFileLoading: Bool = false) {
+        if !skipFileLoading {
+            loadEnvFile()
+        }
     }
     
     /// Access an environment variable
@@ -21,6 +23,39 @@ struct DotEnv {
         
         // Next check our loaded .env variables
         return variables[key]
+    }
+    
+    /// Setup mock environment variables for previews
+    static func setupForPreviews() {
+        print("🔧 Setting up mock environment for previews")
+        
+        // Create a completely new instance that skips loading from file
+        var previewEnv = DotEnv(skipFileLoading: true)
+        
+        // Add mock values for Supabase - these need to be valid formatted values
+        // even though they don't need to point to a real Supabase instance
+        let mockURL = "https://mockproject.supabase.co" 
+        let mockKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.mockkey.T7lOqPdODFmcmVh8VvgUsITLGkBCOuRXz2MxWgBxVD0"
+        
+        previewEnv.variables[EnvironmentVariables.Keys.supabaseURL] = mockURL
+        previewEnv.variables[EnvironmentVariables.Keys.supabaseKey] = mockKey
+        
+        // Also set them in the process environment for processes that check there directly
+        setenv(EnvironmentVariables.Keys.supabaseURL, mockURL, 1)
+        setenv(EnvironmentVariables.Keys.supabaseKey, mockKey, 1)
+        
+        // Replace the shared instance
+        shared = previewEnv
+        
+        print("✅ Mock environment setup complete")
+        
+        // Verify the values are accessible
+        if let url = shared.get(EnvironmentVariables.Keys.supabaseURL),
+           let key = shared.get(EnvironmentVariables.Keys.supabaseKey) {
+            print("🔍 Mock values set: URL=\(url)")
+        } else {
+            print("❌ Failed to verify mock values!")
+        }
     }
     
     /// Load environment variables from .env file

--- a/sna-steward/Utilities/EnvironmentVariables.swift
+++ b/sna-steward/Utilities/EnvironmentVariables.swift
@@ -9,6 +9,14 @@ enum EnvironmentVariables {
     // Use the DotEnv utility to get the values from .env file
     static var supabaseURL: String {
         guard let url = DotEnv.shared.get(Keys.supabaseURL) else {
+            #if DEBUG
+            // For SwiftUI previews, provide a default rather than crashing
+            if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
+                print("⚠️ Using fallback URL for previews")
+                return "https://example-preview-fallback.supabase.co"
+            }
+            #endif
+            
             fatalError("SUPABASE_URL not found in environment variables. Make sure .env file exists.")
         }
         return url
@@ -16,6 +24,14 @@ enum EnvironmentVariables {
     
     static var supabaseKey: String {
         guard let key = DotEnv.shared.get(Keys.supabaseKey) else {
+            #if DEBUG
+            // For SwiftUI previews, provide a default rather than crashing
+            if ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1" {
+                print("⚠️ Using fallback key for previews")
+                return "example-preview-fallback-key"
+            }
+            #endif
+            
             fatalError("SUPABASE_KEY not found in environment variables. Make sure .env file exists.")
         }
         return key

--- a/sna-steward/Utilities/SecureStorage.swift
+++ b/sna-steward/Utilities/SecureStorage.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Security
+
+class SecureStorage {
+    enum Keys: String {
+        case refreshToken = "auth.refreshToken"
+        case accessToken = "auth.accessToken"
+        case userId = "auth.userId"
+        case biometricsEnabled = "auth.biometricsEnabled"
+    }
+    
+    static let shared = SecureStorage()
+    private let service = Bundle.main.bundleIdentifier ?? "com.sna-steward"
+    
+    private init() {}
+    
+    // MARK: - Save methods
+    
+    func save(value: String, for key: Keys) -> Bool {
+        let data = value.data(using: .utf8)!
+        
+        // Query to see if the item already exists
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key.rawValue
+        ]
+        
+        // Remove any existing item
+        SecItemDelete(query as CFDictionary)
+        
+        // Add the new item
+        let saveQuery: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key.rawValue,
+            kSecValueData: data,
+            kSecAttrAccessible: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+        
+        let status = SecItemAdd(saveQuery as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+    
+    // Save Bool
+    func save(value: Bool, for key: Keys) -> Bool {
+        return save(value: value ? "true" : "false", for: key)
+    }
+    
+    // MARK: - Get methods
+    
+    func getValue(for key: Keys) -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key.rawValue,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+        
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        
+        guard status == errSecSuccess, 
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        
+        return value
+    }
+    
+    // Get Bool
+    func getBool(for key: Keys) -> Bool {
+        guard let value = getValue(for: key) else {
+            return false
+        }
+        return value == "true"
+    }
+    
+    // MARK: - Delete methods
+    
+    func delete(key: Keys) -> Bool {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: key.rawValue
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+    
+    // MARK: - Helper methods
+    
+    // Save all auth tokens
+    func saveAuthTokens(accessToken: String, refreshToken: String, userId: String) {
+        _ = save(value: accessToken, for: .accessToken)
+        _ = save(value: refreshToken, for: .refreshToken)
+        _ = save(value: userId, for: .userId)
+    }
+    
+    // Delete all auth tokens
+    func clearAuthTokens() {
+        _ = delete(key: .accessToken)
+        _ = delete(key: .refreshToken)
+        _ = delete(key: .userId)
+    }
+    
+    // Check if tokens exist
+    func hasAuthTokens() -> Bool {
+        return getValue(for: .refreshToken) != nil && getValue(for: .accessToken) != nil
+    }
+} 

--- a/sna-steward/ViewModels/AuthViewModel.swift
+++ b/sna-steward/ViewModels/AuthViewModel.swift
@@ -1,0 +1,245 @@
+import Foundation
+import SwiftUI
+import Combine
+
+class AuthViewModel: ObservableObject {
+    // Published properties for UI binding
+    @Published var email = ""
+    @Published var password = ""
+    @Published var isAuthenticated = false
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    @Published var selectedSnaSite: String?
+    @Published var isFirstTimeUser = false
+    @Published var showBiometricSignIn = false
+    
+    // Private properties
+    private var cancellables = Set<AnyCancellable>()
+    private let supabaseManager = SupabaseManager.shared
+    private let secureStorage = SecureStorage.shared
+    private let biometricsHelper = BiometricAuthHelper.shared
+    
+    init() {
+        // Check if biometrics should be shown
+        showBiometricSignIn = secureStorage.getBool(for: .biometricsEnabled) && 
+                              biometricsHelper.biometricType() != .none &&
+                              secureStorage.hasAuthTokens()
+        
+        // Check authentication state
+        checkAuthState()
+    }
+    
+    // MARK: - Public Methods
+    
+    // Sign in with email and password
+    func signIn() async {
+        errorMessage = nil
+        isLoading = true
+        
+        do {
+            let session = try await supabaseManager.signIn(email: email, password: password)
+            
+            // Store tokens in Keychain
+            secureStorage.saveAuthTokens(
+                accessToken: session.accessToken,
+                refreshToken: session.refreshToken,
+                userId: session.user.id.uuidString
+            )
+            
+            // Check if user is new
+            await checkIfFirstTimeUser()
+            
+            DispatchQueue.main.async {
+                self.isAuthenticated = true
+                self.isLoading = false
+            }
+        } catch {
+            DispatchQueue.main.async {
+                self.errorMessage = error.localizedDescription
+                self.isLoading = false
+            }
+        }
+    }
+    
+    // Sign up with email and password
+    func signUp() async {
+        errorMessage = nil
+        isLoading = true
+        
+        do {
+            let response = try await supabaseManager.signUp(email: email, password: password)
+            
+            DispatchQueue.main.async {
+                self.isLoading = false
+                if response.user != nil {
+                    // User created successfully - auto sign-in will happen if email confirmation is not required
+                    self.isFirstTimeUser = true
+                }
+                // Note: In production app, you might want to show a "verification email sent" message
+            }
+        } catch {
+            DispatchQueue.main.async {
+                self.errorMessage = error.localizedDescription
+                self.isLoading = false
+            }
+        }
+    }
+    
+    // Send magic link
+    func sendMagicLink() async {
+        errorMessage = nil
+        isLoading = true
+        
+        do {
+            try await supabaseManager.signInWithMagicLink(email: email)
+            
+            DispatchQueue.main.async {
+                self.isLoading = false
+                // Show success message or navigate to "check your email" screen
+                self.errorMessage = "Magic link sent to your email"
+            }
+        } catch {
+            DispatchQueue.main.async {
+                self.errorMessage = error.localizedDescription
+                self.isLoading = false
+            }
+        }
+    }
+    
+    // Sign in with biometrics
+    func signInWithBiometrics() async {
+        errorMessage = nil
+        isLoading = true
+        
+        do {
+            // 1. Authenticate with biometrics
+            try await biometricsHelper.authenticate(reason: "Sign in to SNA Steward")
+            
+            // 2. Get stored tokens
+            guard let refreshToken = secureStorage.getValue(for: .refreshToken),
+                  let accessToken = secureStorage.getValue(for: .accessToken) else {
+                throw BiometricAuthHelper.BiometricError.authenticationFailed
+            }
+            
+            // 3. Set the session in Supabase client
+            // This part depends on how your Supabase client is set up to restore a session
+            // You might need to manually create a session object and set it
+            // For now, we'll just set the authenticated flag
+            
+            DispatchQueue.main.async {
+                self.isAuthenticated = true
+                self.isLoading = false
+            }
+        } catch {
+            DispatchQueue.main.async {
+                if let biometricError = error as? BiometricAuthHelper.BiometricError {
+                    self.errorMessage = biometricError.errorDescription
+                } else {
+                    self.errorMessage = error.localizedDescription
+                }
+                self.isLoading = false
+            }
+        }
+    }
+    
+    // Save SNA site for first-time user
+    func saveSnaSite() async {
+        guard let site = selectedSnaSite, !site.isEmpty else {
+            errorMessage = "Please select an SNA site"
+            return
+        }
+        
+        isLoading = true
+        
+        do {
+            try await supabaseManager.updateSnaSiteForCurrentUser(newSite: site)
+            
+            DispatchQueue.main.async {
+                self.isFirstTimeUser = false
+                self.isLoading = false
+            }
+        } catch {
+            DispatchQueue.main.async {
+                self.errorMessage = error.localizedDescription
+                self.isLoading = false
+            }
+        }
+    }
+    
+    // Enable biometric sign-in
+    func enableBiometricSignIn() {
+        secureStorage.save(value: true, for: .biometricsEnabled)
+        showBiometricSignIn = true
+    }
+    
+    // Disable biometric sign-in
+    func disableBiometricSignIn() {
+        secureStorage.save(value: false, for: .biometricsEnabled)
+        showBiometricSignIn = false
+    }
+    
+    // Sign out
+    func signOut() async {
+        isLoading = true
+        
+        do {
+            try await supabaseManager.signOut()
+            
+            // Clear stored tokens
+            secureStorage.clearAuthTokens()
+            
+            DispatchQueue.main.async {
+                self.isAuthenticated = false
+                self.isLoading = false
+                self.email = ""
+                self.password = ""
+            }
+        } catch {
+            DispatchQueue.main.async {
+                self.errorMessage = error.localizedDescription
+                self.isLoading = false
+            }
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    private func checkAuthState() {
+        Task {
+            do {
+                // This depends on how your Supabase client works
+                // You might need to check if there's a valid session
+                let _ = try await supabaseManager.client.auth.session
+                DispatchQueue.main.async {
+                    self.isAuthenticated = true
+                }
+                await checkIfFirstTimeUser()
+            } catch {
+                DispatchQueue.main.async {
+                    self.isAuthenticated = false
+                }
+            }
+        }
+    }
+    
+    private func checkIfFirstTimeUser() async {
+        do {
+            if let profile = try await supabaseManager.fetchCurrentUserStewardProfile(),
+               profile.sna_site != nil {
+                DispatchQueue.main.async {
+                    self.isFirstTimeUser = false
+                    self.selectedSnaSite = profile.sna_site
+                }
+            } else {
+                DispatchQueue.main.async {
+                    self.isFirstTimeUser = true
+                }
+            }
+        } catch {
+            DispatchQueue.main.async {
+                // If we can't fetch profile, assume first time
+                self.isFirstTimeUser = true
+            }
+        }
+    }
+} 

--- a/sna-steward/Views/Auth/PasswordResetView.swift
+++ b/sna-steward/Views/Auth/PasswordResetView.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+
+struct PasswordResetView: View {
+    @ObservedObject var viewModel: AuthViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var resetEmail = ""
+    @State private var resetSent = false
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                VStack(spacing: 20) {
+                    Text("Reset Password")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .padding(.top, 30)
+                    
+                    if resetSent {
+                        // Success view
+                        VStack(spacing: 20) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .font(.system(size: 70))
+                                .foregroundColor(.green)
+                                .padding()
+                            
+                            Text("Password Reset Email Sent")
+                                .font(.headline)
+                            
+                            Text("Please check your inbox at \(resetEmail) for instructions to reset your password.")
+                                .multilineTextAlignment(.center)
+                                .padding()
+                            
+                            Button("Return to Sign In") {
+                                dismiss()
+                            }
+                            .fontWeight(.semibold)
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.blue)
+                            .cornerRadius(8)
+                            .padding(.horizontal)
+                            .padding(.top, 20)
+                        }
+                        .padding()
+                    } else {
+                        // Reset form
+                        VStack(spacing: 15) {
+                            Text("Enter your email address and we'll send you a link to reset your password.")
+                                .multilineTextAlignment(.center)
+                                .padding()
+                            
+                            TextField("Email", text: $resetEmail)
+                                .textContentType(.emailAddress)
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                                .keyboardType(.emailAddress)
+                                .padding()
+                                .background(Color(UIColor.systemGray6))
+                                .cornerRadius(8)
+                                .padding(.horizontal)
+                            
+                            // Error message
+                            if let errorMessage = viewModel.errorMessage {
+                                Text(errorMessage)
+                                    .foregroundColor(.red)
+                                    .font(.footnote)
+                                    .padding(.horizontal)
+                            }
+                            
+                            Button(action: {
+                                // In a real app, connect to Supabase resetPassword function
+                                // For now, we'll simulate success
+                                viewModel.email = resetEmail
+                                Task {
+                                    await viewModel.sendMagicLink()
+                                    resetSent = true
+                                }
+                            }) {
+                                Text("Send Reset Link")
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(.white)
+                                    .frame(maxWidth: .infinity)
+                                    .padding()
+                                    .background(Color.blue)
+                                    .cornerRadius(8)
+                                    .padding(.horizontal)
+                            }
+                            .padding(.top, 10)
+                            
+                            Button("Cancel") {
+                                dismiss()
+                            }
+                            .padding(.top, 10)
+                        }
+                    }
+                    
+                    Spacer()
+                }
+                
+                // Loading state
+                if viewModel.isLoading {
+                    Color.black.opacity(0.3)
+                        .edgesIgnoringSafeArea(.all)
+                    ProgressView()
+                        .scaleEffect(1.5)
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct PasswordResetView_Previews: PreviewProvider {
+    static var previews: some View {
+        PasswordResetView(viewModel: AuthViewModel())
+    }
+} 

--- a/sna-steward/Views/Auth/SelectSnaSiteView.swift
+++ b/sna-steward/Views/Auth/SelectSnaSiteView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct SelectSnaSiteView: View {
+    @ObservedObject var viewModel: AuthViewModel
+    
+    // Example SNA sites - replace with real data fetch
+    private let exampleSites = [
+        "Green Valley SNA",
+        "Blue River SNA",
+        "Eagle Mountain SNA",
+        "Lakeside Preserve SNA",
+        "Pinewood Forest SNA"
+    ]
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                VStack {
+                    Text("Select Your SNA Site")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .padding(.top, 30)
+                    
+                    Text("Welcome to SNA Steward! Please select the SNA site you will be stewarding.")
+                        .multilineTextAlignment(.center)
+                        .padding()
+                    
+                    Picker("SNA Site", selection: $viewModel.selectedSnaSite) {
+                        Text("Select a site").tag(Optional<String>(nil))
+                        ForEach(exampleSites, id: \.self) { site in
+                            Text(site).tag(Optional(site))
+                        }
+                    }
+                    .pickerStyle(MenuPickerStyle())
+                    .padding()
+                    .background(Color(UIColor.systemGray6))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+                    
+                    // Error message
+                    if let errorMessage = viewModel.errorMessage {
+                        Text(errorMessage)
+                            .foregroundColor(.red)
+                            .font(.footnote)
+                            .padding(.horizontal)
+                    }
+                    
+                    Button(action: {
+                        Task {
+                            await viewModel.saveSnaSite()
+                        }
+                    }) {
+                        Text("Continue")
+                            .fontWeight(.semibold)
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(Color.blue)
+                            .cornerRadius(8)
+                            .padding(.horizontal)
+                    }
+                    .padding(.top, 20)
+                    .disabled(viewModel.selectedSnaSite == nil)
+                    
+                    Spacer()
+                    
+                    // Sign out option at bottom
+                    Button(action: {
+                        Task {
+                            await viewModel.signOut()
+                        }
+                    }) {
+                        Text("Sign Out")
+                            .foregroundColor(.red)
+                    }
+                    .padding(.bottom, 20)
+                }
+                
+                // Loading state
+                if viewModel.isLoading {
+                    Color.black.opacity(0.3)
+                        .edgesIgnoringSafeArea(.all)
+                    ProgressView()
+                        .scaleEffect(1.5)
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                }
+            }
+            .navigationBarBackButtonHidden(true)
+        }
+    }
+}
+
+struct SelectSnaSiteView_Previews: PreviewProvider {
+    static var previews: some View {
+        // Create a viewModel with isFirstTimeUser set to true
+        let viewModel = AuthViewModel()
+        SelectSnaSiteView(viewModel: viewModel)
+    }
+} 

--- a/sna-steward/Views/Auth/SignInView.swift
+++ b/sna-steward/Views/Auth/SignInView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+import Foundation
+import Combine
+
+// Import required models
+// @testable import sna_steward
+
+struct SignInView: View {
+    @ObservedObject var viewModel: AuthViewModel
+    @State private var showForgotPassword = false
+    @State private var showSignUp = false
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                VStack(spacing: 20) {
+                    // Logo or App Title
+                    Text("SNA Steward")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .padding(.top, 50)
+                    
+                    Spacer()
+                    
+                    // Sign in form
+                    VStack(spacing: 15) {
+                        TextField("Email", text: $viewModel.email)
+                            .textContentType(.emailAddress)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .keyboardType(.emailAddress)
+                            .padding()
+                            .background(Color(UIColor.systemGray6))
+                            .cornerRadius(8)
+                            .padding(.horizontal)
+                        
+                        SecureField("Password", text: $viewModel.password)
+                            .textContentType(.password)
+                            .padding()
+                            .background(Color(UIColor.systemGray6))
+                            .cornerRadius(8)
+                            .padding(.horizontal)
+                        
+                        // Error message
+                        if let errorMessage = viewModel.errorMessage {
+                            Text(errorMessage)
+                                .foregroundColor(.red)
+                                .font(.footnote)
+                                .padding(.horizontal)
+                        }
+                        
+                        // Sign in button
+                        Button(action: {
+                            Task {
+                                await viewModel.signIn()
+                            }
+                        }) {
+                            Text("Sign In")
+                                .fontWeight(.semibold)
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.blue)
+                                .cornerRadius(8)
+                                .padding(.horizontal)
+                        }
+                        
+                        // Forgot password link
+                        Button("Forgot Password?") {
+                            showForgotPassword = true
+                        }
+                        .font(.footnote)
+                        .foregroundColor(.blue)
+                        .padding(.top, 5)
+                        
+                        Divider()
+                            .padding()
+                        
+                        // Magic link button
+                        Button(action: {
+                            Task {
+                                await viewModel.sendMagicLink()
+                            }
+                        }) {
+                            Text("Sign in with Magic Link")
+                                .fontWeight(.semibold)
+                                .foregroundColor(.blue)
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.white)
+                                .cornerRadius(8)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Color.blue, lineWidth: 1)
+                                )
+                                .padding(.horizontal)
+                        }
+                        
+                        // Biometric authentication button (if available)
+                        if viewModel.showBiometricSignIn {
+                            Button(action: {
+                                Task {
+                                    await viewModel.signInWithBiometrics()
+                                }
+                            }) {
+                                HStack {
+                                    Image(systemName: BiometricAuthHelper.shared.biometricType() == .faceID ? "faceid" : "touchid")
+                                    Text("Sign in with \(BiometricAuthHelper.shared.biometricType().description)")
+                                }
+                                .fontWeight(.semibold)
+                                .foregroundColor(.blue)
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.white)
+                                .cornerRadius(8)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Color.blue, lineWidth: 1)
+                                )
+                                .padding(.horizontal)
+                            }
+                        }
+                    }
+                    
+                    Spacer()
+                    
+                    // Don't have an account? link
+                    HStack {
+                        Text("Don't have an account?")
+                        Button("Sign Up") {
+                            showSignUp = true
+                        }
+                        .foregroundColor(.blue)
+                    }
+                    .padding(.bottom, 20)
+                }
+                
+                // Loading state
+                if viewModel.isLoading {
+                    Color.black.opacity(0.3)
+                        .edgesIgnoringSafeArea(.all)
+                    ProgressView()
+                        .scaleEffect(1.5)
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                }
+            }
+            // Navigation links
+            .sheet(isPresented: $showForgotPassword) {
+                PasswordResetView(viewModel: viewModel)
+            }
+            .sheet(isPresented: $showSignUp) {
+                SignUpView(viewModel: viewModel)
+            }
+            .fullScreenCover(isPresented: $viewModel.isAuthenticated) {
+                if viewModel.isFirstTimeUser {
+                    SelectSnaSiteView(viewModel: viewModel)
+                } else {
+                    // Main app content goes here
+                    MainContentView(viewModel: viewModel)
+                }
+            }
+        }
+    }
+}
+
+// Preview
+struct SignInView_Previews: PreviewProvider {
+    static var previews: some View {
+        // Setup mock environment for preview
+        return SignInView(viewModel: PreviewHelper.createMockAuthViewModel())
+    }
+} 

--- a/sna-steward/Views/Auth/SignUpView.swift
+++ b/sna-steward/Views/Auth/SignUpView.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+
+struct SignUpView: View {
+    @ObservedObject var viewModel: AuthViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var confirmPassword = ""
+    @State private var passwordsMatch = true
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                VStack(spacing: 20) {
+                    Text("Create Account")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                        .padding(.top, 30)
+                    
+                    VStack(spacing: 15) {
+                        TextField("Email", text: $viewModel.email)
+                            .textContentType(.emailAddress)
+                            .keyboardType(.emailAddress)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .padding()
+                            .background(Color(UIColor.systemGray6))
+                            .cornerRadius(8)
+                            .padding(.horizontal)
+                        
+                        SecureField("Password", text: $viewModel.password)
+                            .textContentType(.newPassword)
+                            .padding()
+                            .background(Color(UIColor.systemGray6))
+                            .cornerRadius(8)
+                            .padding(.horizontal)
+                        
+                        SecureField("Confirm Password", text: $confirmPassword)
+                            .textContentType(.newPassword)
+                            .padding()
+                            .background(Color(UIColor.systemGray6))
+                            .cornerRadius(8)
+                            .padding(.horizontal)
+                            .onChange(of: confirmPassword) { newValue in
+                                passwordsMatch = viewModel.password == newValue || newValue.isEmpty
+                            }
+                        
+                        // Password match error
+                        if !passwordsMatch {
+                            Text("Passwords do not match")
+                                .foregroundColor(.red)
+                                .font(.footnote)
+                                .padding(.horizontal)
+                        }
+                        
+                        // Error message from viewModel
+                        if let errorMessage = viewModel.errorMessage {
+                            Text(errorMessage)
+                                .foregroundColor(.red)
+                                .font(.footnote)
+                                .padding(.horizontal)
+                        }
+                        
+                        Button(action: {
+                            guard viewModel.password == confirmPassword else {
+                                passwordsMatch = false
+                                return
+                            }
+                            
+                            Task {
+                                await viewModel.signUp()
+                            }
+                        }) {
+                            Text("Create Account")
+                                .fontWeight(.semibold)
+                                .foregroundColor(.white)
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.blue)
+                                .cornerRadius(8)
+                                .padding(.horizontal)
+                        }
+                        .disabled(viewModel.email.isEmpty || viewModel.password.isEmpty || confirmPassword.isEmpty || !passwordsMatch)
+                        .padding(.top, 10)
+                    }
+                    
+                    Spacer()
+                    
+                    // Already have an account? link
+                    HStack {
+                        Text("Already have an account?")
+                        Button("Sign In") {
+                            dismiss()
+                        }
+                        .foregroundColor(.blue)
+                    }
+                    .padding(.bottom, 20)
+                }
+                
+                // Loading state
+                if viewModel.isLoading {
+                    Color.black.opacity(0.3)
+                        .edgesIgnoringSafeArea(.all)
+                    ProgressView()
+                        .scaleEffect(1.5)
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct SignUpView_Previews: PreviewProvider {
+    static var previews: some View {
+        // Setup mock environment for preview
+        DotEnv.setupForPreviews()
+        
+        return SignUpView(viewModel: AuthViewModel())
+    }
+} 

--- a/sna-steward/Views/MainContentView.swift
+++ b/sna-steward/Views/MainContentView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct MainContentView: View {
+    @ObservedObject var viewModel: AuthViewModel
+    
+    var body: some View {
+        NavigationView {
+            VStack {
+                Text("Welcome to SNA Steward!")
+                    .font(.title)
+                    .padding()
+                
+                if let snaSite = viewModel.selectedSnaSite {
+                    Text("Your SNA Site: \(snaSite)")
+                        .font(.headline)
+                        .padding()
+                }
+                
+                Spacer()
+                
+                // Sign out button
+                Button(action: {
+                    Task {
+                        await viewModel.signOut()
+                    }
+                }) {
+                    Text("Sign Out")
+                        .foregroundColor(.white)
+                        .padding()
+                        .frame(maxWidth: 200)
+                        .background(Color.red)
+                        .cornerRadius(8)
+                }
+                .padding(.bottom, 20)
+            }
+            .navigationTitle("SNA Steward")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+struct MainContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        // Setup mock environment for preview
+        DotEnv.setupForPreviews()
+        
+        let viewModel = AuthViewModel()
+        viewModel.selectedSnaSite = "Green Valley SNA" // Set sample data
+        return MainContentView(viewModel: viewModel)
+    }
+} 

--- a/sna-steward/Views/MainTabView.swift
+++ b/sna-steward/Views/MainTabView.swift
@@ -1,8 +1,14 @@
 import SwiftUI
 
 struct MainTabView: View {
+  @ObservedObject var viewModel: AuthViewModel
+  
     var body: some View {
         TabView {
+          MainContentView(viewModel: viewModel)
+            .tabItem {
+              Label("Home", systemImage: "house")
+            }
             ObservationReportsView()
                 .tabItem {
                     Label("Reports", systemImage: "doc.text")
@@ -90,5 +96,7 @@ struct MapView: View {
 
 
 #Preview {
-    MainTabView()
-} 
+  // Use a pre-authenticated mock view model
+  return MainTabView(viewModel: PreviewHelper.createAuthenticatedViewModel())
+}
+


### PR DESCRIPTION
Adding authentication views for:
- sign in
- sign up
- password reset
- initial site selection

Adding preview initializers for external services